### PR TITLE
Try to remove warnings

### DIFF
--- a/src/features/jobs/JobsView.vue
+++ b/src/features/jobs/JobsView.vue
@@ -18,6 +18,7 @@
     </div>
     <v-card elevation="3">
       <v-list v-if="!loading">
+        <!-- Kann 'v-model="selected"' entfernt werden? Die Zeile führt zu einer Warnung auf der JobsView Seite und die Variable wird sonst nirgendwo verwendet denke ich. Aber sicher bin ich nicht. -->
         <v-list-item-group
           v-model="selected"
           active-class="pink--text"

--- a/src/features/jobs/JobsView.vue
+++ b/src/features/jobs/JobsView.vue
@@ -17,6 +17,7 @@
       </div>
     </div>
     <v-card elevation="3">
+      <!-- Woher kommt die Variable "loading"? Weil sie in dieser Datei nicht weiter definiert ist, kommt es hier zu einer Warnung -->
       <v-list v-if="!loading">
         <!-- Kann 'v-model="selected"' entfernt werden? Die Zeile führt zu einer Warnung auf der JobsView Seite und die Variable wird sonst nirgendwo verwendet denke ich. Aber sicher bin ich nicht. -->
         <v-list-item-group

--- a/src/features/jobs/JobsView.vue
+++ b/src/features/jobs/JobsView.vue
@@ -25,6 +25,7 @@
           active-class="pink--text"
           multiple
         >
+          <!-- Ich bekomme außerdem eine Warnung bzgl. duplizierter IDs. Hast du eine Idee, woher das kommen kann? -->
           <template v-for="(job, index) in Object.values(jobs)">
             <v-list-item link :to="'/output/' + job.id" :key="job.id">
               <v-list-item-content style="flex: 1">{{


### PR DESCRIPTION
Ich bekomme auf der Übersichtsseite immerzu eine Reihe von roten Warnungen in der Konsole wenn die die Seite lade. Ich traue mich aber nicht den Code zu bearbeiten, da du ihn geschrieben hast und ich nicht weiß, ob doch noch aus einer anderen Datei auf die entsprechenden Codezeile zugegriffen wird. Kannst du dir das bitte einmal ansehen? 

![image](https://user-images.githubusercontent.com/61976072/147873098-8e08e048-bd68-4c1b-b46c-7bd89eedee55.png)
